### PR TITLE
feat: add orders_per_month model and tests (Part 2)

### DIFF
--- a/macros/test_is_positive.sql
+++ b/macros/test_is_positive.sql
@@ -1,6 +1,0 @@
-{# macros/test_expression_is_positive.sql #}
-{% macro test_expression_is_positive(model, column_name) %}
-select *
-from {{ model }}
-where {{ column_name }} <= 0
-{% endmacro %}

--- a/macros/test_no_negative.sql
+++ b/macros/test_no_negative.sql
@@ -1,0 +1,6 @@
+{# macros/test_no_negative.sql #}
+{% macro test_no_negative(model, column_name) %}
+select *
+from {{ model }}
+where {{ column_name }} < 0
+{% endmacro %}

--- a/models/customer_sales.sql
+++ b/models/customer_sales.sql
@@ -8,3 +8,4 @@ select
   sum(amount) as total_sales
 from {{ source('neon_source', 'sales_data') }}
 group by customer_id
+order by customer_id

--- a/models/orders_per_month.sql
+++ b/models/orders_per_month.sql
@@ -1,0 +1,11 @@
+-- models/orders_per_month.sql
+-- Purpose:  (Part 2)
+
+{{ config(materialized='table') }}
+
+select
+  date_trunc('month', order_date)::date as order_month,
+  count(*) as orders_count
+from {{ source('neon_source', 'sales_data') }}
+group by order_month
+order by order_month

--- a/models/schema.yml
+++ b/models/schema.yml
@@ -21,5 +21,18 @@ models:
         description: "Total sales amount (sum of amount) for each customer."
         tests:
           - not_null
-          - expression_is_positive
+          - no_negative
+
+  - name: orders_per_month
+    description: "Monthly order counts derived from sales_data (one row per month)."
+    columns:
+      - name: order_month
+        description: "First day of the month representing the month window (YYYY-MM-DD)."
+        tests:
+          - not_null
+      - name: orders_count
+        description: "Number of orders in the month."
+        tests:
+          - not_null
+          - no_negative
 


### PR DESCRIPTION
- Added orders_per_month model to count orders per calendar month from neon_source.sales_data.
- Change custom test expresion_is_positive to no_negative
- Updated models/schema.yml with model description and tests (not_null, custom no_negative).
- Validated in Neon and ran tests locally in dbt Cloud.