### PR TITLE
feat: implement incremental orders_per_month (Part 3)

### DIFF
--- a/models/orders_per_month_incremental.sql
+++ b/models/orders_per_month_incremental.sql
@@ -1,0 +1,23 @@
+-- models/orders_per_month_incremental.sql
+-- Purpose: Incrementally track number of orders per month. This model appends new sales data based on order_date.
+
+{{ config(
+    materialized='incremental',
+    unique_key='order_month',
+    incremental_strategy='merge'
+) }}
+
+with new_orders as (
+    select
+        date_trunc('month', order_date)::date as order_month,
+        count(*) as orders_count
+    from {{ source('snowflake_source', 'sales_data') }}
+    {% if is_incremental() %}
+        -- Only process sales newer than the latest month already in the table
+        where date_trunc('month', order_date) > (select max(order_month) from {{ this }})
+    {% endif %}
+    group by order_month
+)
+
+select *
+from new_orders

--- a/models/schema.yml
+++ b/models/schema.yml
@@ -36,3 +36,18 @@ models:
           - not_null
           - no_negative
 
+  - name: orders_per_month_incremental
+    description: "Incremental version of monthly order counts. Appends new data when sales_data refreshes."
+    columns:
+      - name: order_month
+        description: "Month of the orders (YYYY-MM-DD)."
+        tests:
+          - not_null
+          - unique
+      - name: orders_count
+        description: "Number of orders aggregated incrementally."
+        tests:
+          - not_null
+          - expression_is_non_negative
+
+


### PR DESCRIPTION
- Add orders_per_month incremental model.
- Configured unique_key=order_month and merge for incremental updates.
- Added incremental filter (is_incremental()) to process only new records.
- Updated schema.yml to include unique test for order_month and non-negative validation for counts.